### PR TITLE
missing dependency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The core MathWebSearch executables require:
   - libleveldb
   - libsnappy
   - libjson-c
+  - libjson0-dev
 
 The crawler executables require:
   - libhtmlcxx-dev


### PR DESCRIPTION
I've just tried to build mws on Ubuntu 16.04 and got the following error:

- Could NOT find JSON (missing:  JSON_INCLUDE_DIRS) 

I've had all the dependencies installed, in particular libjson-c-dev. The error went away after installing libjson0-dev, so I would suggest to add that in the README. 